### PR TITLE
Add publication date for events in content editor (416)

### DIFF
--- a/src/components/semantic/metaItems.tsx
+++ b/src/components/semantic/metaItems.tsx
@@ -159,6 +159,7 @@ export const MetaItems = asMetaItems({
   ],
   bookingDeadline: ["Booking Deadline", { presenter: DateTimeInput }],
   prepWorkDeadline: ["Prep-work Deadline", { presenter: DateTimeInput }],
+  publicationDate: ["Publication Date", { presenter: DateTimeInput }],
   numberOfPlaces: ["Number of places", { type: "number" }],
   eventStatus: [
     "Status",

--- a/src/components/semantic/registry.tsx
+++ b/src/components/semantic/registry.tsx
@@ -229,6 +229,7 @@ const isaacEventPage: RegistryEntry = {
     "end_date",
     "bookingDeadline",
     "prepWorkDeadline",
+    "publicationDate",
     "numberOfPlaces",
     "eventStatus",
     "location",


### PR DESCRIPTION
https://github.com/isaaccomputerscience/isaac-cs-issues/issues/416

The programmes team aren't able to easily see when an event has been published, so they can't see exactly when an event has gone live. The publication date of events to be visible in the content editor